### PR TITLE
replace http with https

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: vault:1.4.2
     container_name: vault-init
     environment:
-      - VAULT_ADDR=http://vault:8200
+      - VAULT_ADDR=https://vault:8200
       - MY_VAULT_TOKEN=${MY_VAULT_TOKEN:-test}
     volumes:
       - ./vault-root-token:/vault/file/vault-root-token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: vault:1.4.2
     container_name: vault-init
     environment:
-      - VAULT_ADDR=https://vault:8200
+      - VAULT_ADDR=http://vault:8200
       - MY_VAULT_TOKEN=${MY_VAULT_TOKEN:-test}
     volumes:
       - ./vault-root-token:/vault/file/vault-root-token

--- a/vault-init.sh
+++ b/vault-init.sh
@@ -3,22 +3,22 @@
 set -ex
 
 unseal () {
-vault operator unseal $(grep 'Key 1:' /vault/file/keys | awk '{print $NF}')
-vault operator unseal $(grep 'Key 2:' /vault/file/keys | awk '{print $NF}')
-vault operator unseal $(grep 'Key 3:' /vault/file/keys | awk '{print $NF}')
+vault operator unseal -tls-skip-verify $(grep 'Key 1:' /vault/file/keys | awk '{print $NF}')
+vault operator unseal -tls-skip-verify $(grep 'Key 2:' /vault/file/keys | awk '{print $NF}')
+vault operator unseal -tls-skip-verify $(grep 'Key 3:' /vault/file/keys | awk '{print $NF}')
 }
 
 init () {
-vault operator init > /vault/file/keys
+vault operator init -tls-skip-verify > /vault/file/keys
 }
 
 log_in () {
    export ROOT_TOKEN=$(grep 'Initial Root Token:' /vault/file/keys | awk '{print $NF}')
-   vault login $ROOT_TOKEN
+   vault login -tls-skip-verify $ROOT_TOKEN
 }
 
 create_token () {
-   vault token create -id $MY_VAULT_TOKEN
+   vault token create -tls-skip-verify -id $MY_VAULT_TOKEN
 }
 
 if [ -s /vault/file/keys ]; then
@@ -30,4 +30,4 @@ else
    create_token
 fi
 
-vault status > /vault/file/status
+vault status -tls-skip-verify > /vault/file/status


### PR DESCRIPTION
After using `docker-compose up -d`, I got this error in the vault-init container :
```
vault-init    | + '[' -s /vault/file/keys ]
vault-init    | + init
vault-init    | + vault operator init
vault-init    | Error initializing: Error making API request.
vault-init    | 
vault-init    | URL: PUT http://vault:8200/v1/sys/init
vault-init    | Code: 400. Raw Message:
vault-init    | 
vault-init    | Client sent an HTTP request to an HTTPS server.
vault-init    | 
```
So I changed http://vault:8200 to `HTTPS`, and in this script, we must use `-tls-skip-verify` to resolve this error.